### PR TITLE
Update docker.clj

### DIFF
--- a/src/com/palletops/docker.clj
+++ b/src/com/palletops/docker.clj
@@ -4,6 +4,7 @@
    [cheshire.core :as json]
    [clj-http.client :as http]
    [clj-http.core :as http-core]
+   [clj-http.util :as http-util]
    [clojure.java.io :refer [copy file reader]]
    [clojure.string :as string :refer [blank? lower-case split]]
    [com.palletops.api-builder.api
@@ -66,7 +67,7 @@
   (let [^String charset (or charset
                             (-> resp :content-type-params :charset)
                             "UTF-8")
-        body (clj-http.util/force-byte-array body)
+        body (http-util/force-byte-array body)
         decode-func json-decode]
     (debugf "coerce-json-body %s %s" coerce (http/unexceptional-status? status))
     (cond


### PR DESCRIPTION
When I run "lein uberimage" I get the following error:

"No such var: clj-http.util/force-byte-array, compiling:(com/palletops/docker.clj:69:14)"

I **think** that this is because you have not required clj-http.util in your ns, and you have only required in some parts of the cli-http namespace, so your original use of cli-http.util on line 69 is causing the compile error above.

I have added a require for cli-http.util and updated the function call on line 69 appropriately.

Thanks in advance - apologies if I've missed something obvious; I have no idea how I could test this locally as if I were to meddle with the clj-docker .jar in my ~/.m2 repo I am pretty sure that lein would barf because the .sha would no longer match.
